### PR TITLE
Ez5.4+

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -16,8 +16,9 @@ class DefaultController extends Controller {
         $response->setSharedMaxAge( 86400 );
         $response->headers->set( 'X-Location-Id', 2 );
         $response->headers->set('Content-Type', 'application/xml');
-        $searchService = $this->getRepository()->getSearchService();
-        $locationService = $this->getRepository()->getLocationService();
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $locationService = $repository->getLocationService();
 
         $classes = $this->container->getParameter('tutei_sitemap.classes');
         $url =  $this->container->getParameter('tutei_sitemap.base_url');
@@ -28,6 +29,7 @@ class DefaultController extends Controller {
                 new ContentTypeIdentifier($classes)
             )
         );
+
         $list = $searchService->findContent($query);
 
         $results = array();
@@ -40,7 +42,7 @@ class DefaultController extends Controller {
             $results[] = $locationService->loadLocation($locationId);
         }
 
-        return $this->render('TuteiSitemapBundle:Default:index.xml.twig', 
+        return $this->render('TuteiSitemapBundle:Default:index.xml.twig',
                 array('results' => $results, 'url'=>$url),
                 $response);
     }

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -30,7 +30,6 @@ class DefaultController extends Controller {
         $rootLocation = $locationService->loadLocation($rootLocationId);
 
         $classes = $this->container->getParameter($classes_parameter);
-        $url =  $this->container->getParameter('tutei_sitemap.base_url');
 
         $query = new Query();
         $query->query = new LogicalAnd(
@@ -53,7 +52,7 @@ class DefaultController extends Controller {
         }
 
         return $this->render('TuteiSitemapBundle:Default:index.xml.twig',
-                array('results' => $results, 'url'=>$url),
+                array('results' => $results),
                 $response);
     }
 

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -3,6 +3,7 @@
 namespace Tutei\SitemapBundle\Controller;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
@@ -20,12 +21,21 @@ class DefaultController extends Controller {
         $searchService = $repository->getSearchService();
         $locationService = $repository->getLocationService();
 
+        $configResolver = $this->getConfigResolver();
+        $rootLocationIdParameter = 'content.tree_root.location_id';
+        $rootLocationId = $configResolver->hasParameter($rootLocationIdParameter) ?
+            $configResolver->getParameter($rootLocationIdParameter)
+            :
+            2;
+        $rootLocation = $locationService->loadLocation($rootLocationId);
+
         $classes = $this->container->getParameter('tutei_sitemap.classes');
         $url =  $this->container->getParameter('tutei_sitemap.base_url');
 
         $query = new Query();
         $query->query = new LogicalAnd(
             array(
+                new Subtree($rootLocation->pathString),
                 new ContentTypeIdentifier($classes)
             )
         );

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -5,7 +5,6 @@ namespace Tutei\SitemapBundle\Controller;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
-use eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationPathString;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -24,14 +23,10 @@ class DefaultController extends Controller {
         $url =  $this->container->getParameter('tutei_sitemap.base_url');
 
         $query = new Query();
-
-        $query->criterion = new LogicalAnd(
-                array(
-            new ContentTypeIdentifier($classes)
-                )
-        );
-        $query->sortClauses = array(
-            new LocationPathString(Query::SORT_ASC)
+        $query->query = new LogicalAnd(
+            array(
+                new ContentTypeIdentifier($classes)
+            )
         );
         $list = $searchService->findContent($query);
 

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DefaultController extends Controller {
 
-    public function indexAction() {
+    public function indexAction($classes_parameter = 'tutei_sitemap.classes') {
         $response = new Response();
         $response->setPublic();
         $response->setSharedMaxAge( 86400 );
@@ -29,7 +29,7 @@ class DefaultController extends Controller {
             2;
         $rootLocation = $locationService->loadLocation($rootLocationId);
 
-        $classes = $this->container->getParameter('tutei_sitemap.classes');
+        $classes = $this->container->getParameter($classes_parameter);
         $url =  $this->container->getParameter('tutei_sitemap.base_url');
 
         $query = new Query();

--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ By default, the sitemap takes the whole tree. If you want to restrict this to yo
     parameters:
         ezsettings.mysiteaccess.content.tree_root.location_id: 92
 
+### How to handle multiple sitemaps with different classes?
+
+1. Add parameters to your `default_settings.yml`
+
+        sitemap.classes:
+            - home
+            - blog_post
+            - landing
+
+        google_news_sitemap.classes:
+            -blog_post
+
+2. Create a new route for each sitemap
+
+        sitemap:
+            pattern: /sitemap.xml
+            defaults: { _controller: TuteiSitemapBundle:Default:index, classes_parameter: sitemap.classes }
+        google_news_sitemap:
+            pattern: /sitemap-news.xml
+            defaults: { _controller: TuteiSitemapBundle:Default:index, classes_parameter: google_news_sitemap.classes }
+
 ## How to use
 
 To view your sitemap access: `/sitemap.xml`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ By default, the sitemap takes the whole tree. If you want to restrict this to yo
             - landing
 
         google_news_sitemap.classes:
-            -blog_post
+            - blog_post
 
 2. Create a new route for each sitemap
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Run the following to install the bundle assets:
 Example parameters are in `/src/Tutei/SitemapBundle/Resources/config/services.yml`
 Copy and modify these to your own `services.yml`
 
+### How to target a specific siteaccess content tree?
+
+By default, the sitemap takes the whole tree. If you want to restrict this to your siteaccess content tree, add `content.tree_root.location_id` parameter to your `default_settings.yml`. Example:
+
+    parameters:
+        ezsettings.mysiteaccess.content.tree_root.location_id: 92
+
 # How to use
 
 To view your sitemap access: `/sitemap.xml`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A simple eZ Publish 5 bundle providing a controller to generate an XML sitemap on the fly.
 It provides a human-readable stylesheet.
 
-# How to install
+## How to install
 
 Install into vendors using composer:
 
@@ -26,7 +26,9 @@ Run the following to install the bundle assets:
 
     php ezpublish/console assets:install --symlink web
 
-# How to configure
+## How to configure
+
+### Minimal configuration
 
 Example parameters are in `/src/Tutei/SitemapBundle/Resources/config/services.yml`
 Copy and modify these to your own `services.yml`
@@ -38,6 +40,6 @@ By default, the sitemap takes the whole tree. If you want to restrict this to yo
     parameters:
         ezsettings.mysiteaccess.content.tree_root.location_id: 92
 
-# How to use
+## How to use
 
 To view your sitemap access: `/sitemap.xml`

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,6 +2,3 @@ parameters:
     tutei_sitemap.classes:
         - folder
         - article
-
-    tutei_sitemap.base_url:
-        http://test.com

--- a/Resources/views/Default/index.xml.twig
+++ b/Resources/views/Default/index.xml.twig
@@ -4,7 +4,7 @@
     {% for result in results %}
 
     <url>
-      <loc>{{ url }}{{ path(result) }}</loc>
+      <loc>{{ url(result) }}</loc>
       <lastmod>{{ result.contentInfo.modificationDate|date('Y-m-d') }}</lastmod>
     </url>
     {%endfor%}


### PR DESCRIPTION
Hi there,
First of all, thanks for this useful bundle. I tried to used it with my eZ5.4 version and it didn't work out of the box because of deprecated call:
- `$query->criterion` -> `$query->query`
- `SortClause\LocationPathString`

There is no sort option in my code anymore but I don't think it is harmful.

I added two options. One to change the default root node fetched and the other one to handling specifics classes on multiple sitemaps generation.

I can totally understand that you don't want to merge this into your master branch if you are not using eZ5.4+ but you can consider to put this into a custom branch.

Have a nice day.
